### PR TITLE
Update the version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>underscore.string</artifactId>
-    <version>2.3.4-SNAPSHOT</version>
+    <version>3.2.1</version>
     <name>Underscore.string</name>
     <description>WebJar for Underscore.string</description>
     <url>http://webjars.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>underscore.string</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.1-SNAPSHOT</version>
     <name>Underscore.string</name>
     <description>WebJar for Underscore.string</description>
     <url>http://webjars.org</url>


### PR DESCRIPTION
I need the latest version of underscore.string available as a webjar.  I think I've updated the pom correctly.  I've tested this by running a mvn clean compile.

I've choose 3.2.1 because it is the latest release version on their github.
https://github.com/epeli/underscore.string/releases